### PR TITLE
Add numba implementation of a Hilbert R-tree

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,14 @@
-This work includes components that were originally developed in the fletcher library by
-Uwe L. Korn which is distributed under the following licence:
+The geometry extension arrays in this project include components that were
+originally developed in the fletcher library (https://github.com/xhochy/fletcher)
+by Uwe L. Korn  (copyright 2018) which is distributed under the MIT License.
 
+The Hilbert curve functions include components that were originally developed in the
+hilbertcurve library (https://github.com/galtay/hilbertcurve) by Gabriel Altay
+(copyright 2017) which is distributed under the MIT License.
+
+Licenses
+--------
 MIT License
-
-Copyright (c) 2018 Uwe L. Korn
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -3,4 +3,4 @@ from setuptools import setup, find_packages
 setup(name='spatialpandas',
       packages=find_packages(exclude=('tests',)),
       install_requires=['pandas', 'dask', 'numba', 'numpy', 'pyarrow>=0.15'],
-      tests_require=['pytest', 'hypothesis'])
+      tests_require=['pytest', 'hypothesis', 'hilbertcurve'])

--- a/spatialpandas/__init__.py
+++ b/spatialpandas/__init__.py
@@ -1,1 +1,2 @@
 from . import geometry
+from . import spatialindex

--- a/spatialpandas/spatialindex/__init__.py
+++ b/spatialpandas/spatialindex/__init__.py
@@ -1,0 +1,1 @@
+from .rtree import HilbertRtree

--- a/spatialpandas/spatialindex/hilbert_curve.py
+++ b/spatialpandas/spatialindex/hilbert_curve.py
@@ -1,0 +1,187 @@
+from __future__ import absolute_import
+import numpy as np
+from spatialpandas.utils import ngjit
+
+"""
+Initially based on https://github.com/galtay/hilbert_curve, but specialized
+for 2 dimensions with numba acceleration
+"""
+
+
+@ngjit
+def _int_2_binary(v, width):
+    """Return a binary byte array representation of `v` zero padded to `width`
+    bits."""
+    res = np.zeros(width, dtype=np.uint8)
+    for i in range(width):
+        res[width - i - 1] = v % 2
+        v = v >> 1
+    return res
+
+
+@ngjit
+def _binary_2_int(bin_vec):
+    """Convert a binary byte array to an integer"""
+    res = 0
+    next_val = 1
+    width = len(bin_vec)
+    for i in range(width):
+        res += next_val*bin_vec[width - i - 1]
+        next_val <<= 1
+    return res
+
+
+@ngjit
+def _hilbert_integer_to_transpose(p, h, n):
+    """Store a hilbert integer (`h`) as its transpose (`x`).
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        h (int): integer distance along hilbert curve
+        n (int): number of dimensions
+    Returns:
+        x (list): transpose of h
+                  (n components with values between 0 and 2**p-1)
+    """
+    h_bits = _int_2_binary(h, p * n)
+
+    x = [_binary_2_int(h_bits[i::n]) for i in range(n)]
+    return x
+
+
+@ngjit
+def _transpose_to_hilbert_integer(p, coord):
+    """Restore a hilbert integer (`h`) from its transpose (`x`).
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        x (list): transpose of h
+                  (n components with values between 0 and 2**p-1)
+
+    Returns:
+        h (int): integer distance along hilbert curve
+    """
+    n = len(coord)
+    bins = [_int_2_binary(v, p) for v in coord]
+    concat = np.zeros(n*p, dtype=np.uint8)
+    for i in range(p):
+        for j in range(n):
+            concat[n*i + j] = bins[j][i]
+
+    h = _binary_2_int(concat)
+    return h
+
+
+@ngjit
+def coordinate_from_distance(p, n, h):
+    """Return the coordinate for a hilbert distance.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        n (int): number of dimensions
+        h (int): integer distance along hilbert curve
+    Returns:
+        coord (list): Coordinate as length-n list
+    """
+    coord = _hilbert_integer_to_transpose(p, h, n)
+    Z = 2 << (p-1)
+
+    # Gray decode by H ^ (H/2)
+    t = coord[n-1] >> 1
+    for i in range(n-1, 0, -1):
+        coord[i] ^= coord[i-1]
+    coord[0] ^= t
+
+    # Undo excess work
+    Q = 2
+    while Q != Z:
+        P = Q - 1
+        for i in range(n-1, -1, -1):
+            if coord[i] & Q:
+                # invert
+                coord[0] ^= P
+            else:
+                # exchange
+                t = (coord[0] ^ coord[i]) & P
+                coord[0] ^= t
+                coord[i] ^= t
+        Q <<= 1
+
+    return coord
+
+
+@ngjit
+def coordinates_from_distances(p, n, h):
+    """Return the coordinates for an array of hilbert distances.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        n (int): number of dimensions
+        h (ndarray): 1d array of integer distances along hilbert curve
+    Returns:
+        coords (list): 2d array of coordinate, each row a coordinate corresponding to
+            associated distance value in input.
+    """
+    result = np.zeros((len(h), n), dtype=np.int64)
+
+    for i in range(len(h)):
+        result[i, :] = coordinate_from_distance(p, n, h[i])
+
+    return result
+
+
+@ngjit
+def distance_from_coordinate(p, coord):
+    """Return the hilbert distance for a given coordinate.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        coords (ndarray): coordinate as 1d array
+    Returns:
+        h (int): distance
+    """
+    n = len(coord)
+    M = 1 << (p - 1)
+    # Inverse undo excess work
+    Q = M
+    while Q > 1:
+        P = Q - 1
+        for i in range(n):
+            if coord[i] & Q:
+                coord[0] ^= P
+            else:
+                t = (coord[0] ^ coord[i]) & P
+                coord[0] ^= t
+                coord[i] ^= t
+        Q >>= 1
+    # Gray encode
+    for i in range(1, n):
+        coord[i] ^= coord[i - 1]
+    t = 0
+    Q = M
+    while Q > 1:
+        if coord[n - 1] & Q:
+            t ^= Q - 1
+        Q >>= 1
+    for i in range(n):
+        coord[i] ^= t
+    h = _transpose_to_hilbert_integer(p, coord)
+    return h
+
+
+@ngjit
+def distances_from_coordinates(p, coords):
+    """Return the hilbert distances for a given set of coordinates.
+
+    Args:
+        p (int): iterations to use in the hilbert curve
+        coords (ndarray): 2d array of coordinates, one coordinate per row
+    Returns:
+        h (ndarray): 1d array of distances
+    """
+    coords = np.atleast_2d(coords).copy()
+    result = np.zeros(coords.shape[0], dtype=np.int64)
+    for i in range(coords.shape[0]):
+        coord = coords[i, :]
+        result[i] = distance_from_coordinate(p, coord)
+    return result

--- a/spatialpandas/spatialindex/rtree.py
+++ b/spatialpandas/spatialindex/rtree.py
@@ -152,7 +152,7 @@ class HilbertRtree(object):
             p: The Hilbert curve order parameter that determines the resolution
                 of the 2D grid that data points are rounded to before computing
                 their Hilbert distance. Points will be discretized into 2 ** p
-                bins in each the x and y dimensions.
+                bins in both the x and y dimensions.
             page_size: Number of elements per leaf of the tree.
         """
         # Validate/coerce inputs

--- a/spatialpandas/spatialindex/rtree.py
+++ b/spatialpandas/spatialindex/rtree.py
@@ -1,0 +1,349 @@
+import numpy as np
+from numba import jitclass
+from numba import int64, float64
+
+from spatialpandas.spatialindex.hilbert_curve import (
+    distances_from_coordinates
+)
+from spatialpandas.utils import ngjit, _data2coord
+
+
+@ngjit
+def _left_child(node):
+    """
+    Args:
+        node: index of a binary tree node
+
+    Returns:
+        index of node's left child
+    """
+    return 2 * node + 1
+
+
+@ngjit
+def _right_child(node):
+    """
+    Args:
+        node: index of a binary tree node
+
+    Returns:
+        index of node's right child
+    """
+    return 2 * node + 2
+
+
+@ngjit
+def _parent(node):
+    """
+    Args:
+        node: index of a binary tree node
+
+    Returns:
+        index of node's parent
+    """
+    return (node - 1) // 2
+
+
+class HilbertRtree(object):
+    """
+    This class provides a numba implementation of a read-only Hilbert R-tree
+    spatial index
+
+    See https://en.wikipedia.org/wiki/Hilbert_R-tree for more info on the Hilbert R-tree
+
+    This implementation stores the R-tree as an array representation of a binary tree.
+    See https://en.wikipedia.org/wiki/Binary_tree#Arrays for more info on the array
+    representation of a binary tree.
+    """
+
+    @staticmethod
+    @ngjit
+    def _build_hilbert_rtree(bounds, p, page_size):
+        """
+        numba function to construct a Hilbert Rtree
+
+        See HilbertRtree.__init__ for parameter descriptions
+        """
+        # Init bounds_tree array for storing the binary tree representation
+        input_size = bounds.shape[0]
+        n = bounds.shape[1] // 2
+        num_pages = int(np.ceil(input_size / page_size))
+
+        tree_depth = int(np.ceil(np.log2(num_pages)))
+        next_pow2 = 2 ** tree_depth
+        tree_length = next_pow2 * 2 - 1
+        bounds_tree = np.full((tree_length, 2 * n), np.nan)
+        leaf_start = tree_length - next_pow2
+
+        # Compute Hilbert distances for inputs
+        side_length = 2 ** p
+        dim_ranges = [(bounds[:, d].min(), bounds[:, d + n].max()) for d in range(n)]
+
+        # Avoid degenerate case where there is a single unique rectangle that is a
+        # single point. Increase the range by 1.0 to prevent divide by zero error
+        for d in range(n):
+            if dim_ranges[d][0] == dim_ranges[d][1]:
+                dim_ranges[d] = (dim_ranges[d][0], dim_ranges[d][1] + 1)
+
+        # Compute hilbert distance of the middle of each bounding box
+        dim_mids = [(bounds[:, d] + bounds[:, d + n]) / 2.0 for d in range(n)]
+        coords = np.zeros((bounds.shape[0], n), dtype=np.int64)
+        for d in range(n):
+            coords[:, d] = _data2coord(dim_mids[d], dim_ranges[d], side_length)
+        hilbert_distances = distances_from_coordinates(p, coords)
+
+        # Calculate indices needed to sort bounds by hilbert distance
+        keys = np.argsort(hilbert_distances)
+
+        # Populate leaves of the tree, one leaf per page. This is layer = tree_depth
+        sorted_bounds = bounds[keys, :]
+        for page in range(num_pages):
+            start = page * page_size
+            stop = start + page_size
+            page_bounds = sorted_bounds[start:stop, :]
+            d_mins = [np.min(page_bounds[:, d]) for d in range(n)]
+            d_maxes = [np.max(page_bounds[:, d + n]) for d in range(n)]
+            d_ranges = d_mins + d_maxes
+            bounds_tree[leaf_start + page, :] = d_ranges
+
+        # Populate internal layers of tree
+        layer = tree_depth - 1
+        start = _parent(tree_length - next_pow2)
+        stop = _parent(tree_length - 1)
+
+        while layer >= 0:
+            for node in range(start, stop + 1):
+                left_bounds = bounds_tree[_left_child(node), :]
+                left_valid = not np.isnan(left_bounds[0])
+                right_bounds = bounds_tree[_right_child(node), :]
+                right_valid = not np.isnan(right_bounds[0])
+
+                if left_valid:
+                    if right_valid:
+                        d_mins = [min(left_bounds[d], right_bounds[d]) for d in range(n)]
+                        d_maxes = [max(left_bounds[d + n], right_bounds[d + n]) for d in range(n)]
+                        d_ranges = d_mins + d_maxes
+                        bounds_tree[node, :] = d_ranges
+                    else:
+                        bounds_tree[node, :] = left_bounds
+
+                elif right_valid:
+                    bounds_tree[node, :] = right_bounds
+
+            # update layer, start/stop
+            start = _parent(start)
+            stop = _parent(stop)
+            layer -= 1
+
+        return sorted_bounds, keys, bounds_tree
+
+    def __init__(self, bounds, p=10, page_size=512):
+        """
+        Construct a new HilbertRtree
+
+        Args:
+            bounds: A 2-dimensional numpy array representing a collection of
+                n-dimensional bounding boxes. One row per bounding box with
+                2*n columns containing the coordinates of each bounding box as follows:
+                    - bounds[:, 0:n] contains the min values of the bounding boxes,
+                        one column for each of the n dimensions
+                    - bounds[:, n+1:2n] contains the max values of the bounding boxes,
+                        one column for each of the n dimensions
+            p: The Hilbert curve order parameter that determines the resolution
+                of the 2D grid that data points are rounded to before computing
+                their Hilbert distance. Points will be discretized into 2 ** p
+                bins in each the x and y dimensions.
+            page_size: Number of elements per leaf of the tree.
+        """
+        # Validate/coerce inputs
+        if len(bounds.shape) != 2:
+            raise ValueError("bounds must be a 2D array")
+
+        if bounds.shape[0] == 0:
+            raise ValueError("The first dimension of bounds must not be empty")
+
+        if bounds.shape[1] % 2 != 0:
+            raise ValueError("The second dimension of bounds must be a multiple of 2")
+
+        self._page_size = max(1, page_size)  # 1 is smallest valid page size
+        self._numba_rtree = None
+        self._sorted_bounds, self._keys, self._bounds_tree = \
+            HilbertRtree._build_hilbert_rtree(bounds, p, self._page_size)
+
+    def __getstate__(self):
+        # Remove _NumbaRtree instance during serialization since jitclass instances
+        # don't support it.
+        state = self.__dict__
+        state['_numba_rtree'] = None
+        return state
+
+    @property
+    def numba_rtree(self):
+        """
+        Returns:
+            _NumbaRtree jitclass instance that is suitable for use inside numba
+            functions
+        """
+        if self._numba_rtree is None:
+            self._numba_rtree = _NumbaRtree(
+                self._sorted_bounds, self._keys, self._page_size, self._bounds_tree
+            )
+        return self._numba_rtree
+
+    def intersection(self, query_bounds):
+        """
+        Compute the indices of the input bounding boxes that intersect with the
+        supplied query bounds
+
+        Args:
+            query_bounds: An array of the form [min0, min1, ..., max0, max1, ...]
+                representing the bounds to calculate intersections against
+
+        Returns:
+            1d numpy array of the indices of all of the rows in the input bounds array
+            that intersect with query_bounds
+        """
+        return self.numba_rtree.intersection(query_bounds)
+
+
+_numbartree_spec = [
+    ('_bounds', float64[:, :]),
+    ('_keys', int64[:]),
+    ('_page_size', int64),
+    ('_bounds_tree', float64[:, :]),
+]
+@jitclass(_numbartree_spec)
+class _NumbaRtree(object):
+    def __init__(self, bounds, keys, page_size, bounds_tree):
+        self._bounds = bounds
+        self._keys = keys
+        self._page_size = page_size
+        self._bounds_tree = bounds_tree
+
+    def _leaf_start(self):
+        """
+        Returns
+            Index of the first leaf node in bounds_tree
+        """
+        return (self._bounds_tree.shape[0] + 1) // 2 - 1
+
+    def _start_index(self, node):
+        """
+        Args
+            node: Index into _bounds_tree representing a binary tree node
+        Returns
+            The first index into keys represented by node
+        """
+        leaf_start = self._leaf_start()
+        while True:
+            child = _left_child(node)
+            if child >= self._bounds_tree.shape[0]:
+                page = node - leaf_start
+                return page * self._page_size
+            else:
+                node = child
+
+    def _stop_index(self, node):
+        """
+        Args
+            node: Index into _bounds_tree representing a binary tree node
+        Returns
+            One past the last index into keys represented by node
+        """
+        leaf_start = self._leaf_start()
+        while True:
+            child = _right_child(node)
+            if child >= self._bounds_tree.shape[0]:
+                page = node - leaf_start + 1
+                return page * self._page_size
+            else:
+                node = child
+
+    def intersection(self, query_bounds):
+        """
+        See HilbertRtree.intersection
+        """
+        if len(query_bounds) % 2 != 0:
+            raise ValueError(
+                'query_bounds must an array with an even number of elements'
+            )
+
+        n = len(query_bounds) // 2
+
+        nodes = [0]
+        intersect_ranges = []
+        maybe_intersect_ranges = []
+
+        # Find ranges of indices that overlap with query bounds
+        while nodes:
+            next_node = nodes.pop()
+            node_bounds = self._bounds_tree[next_node, :]
+
+            # Check if node's bounds are fully outside query bounds
+            outside = False
+            for d in range(n):
+                if (query_bounds[n + d] < node_bounds[d] or
+                        query_bounds[d] > node_bounds[n + d]):
+                    outside = True
+                    break
+
+            if outside:
+                continue
+
+            # Check if node's bounds are fully inside query bounds
+            inside = True
+            for d in range(n):
+                if (node_bounds[d] < query_bounds[d] or
+                        node_bounds[n + d] > query_bounds[n + d]):
+                    inside = False
+                    break
+
+            if inside:
+                # Node's bounds are fully inside query bounds
+                start = self._start_index(next_node)
+                stop = self._stop_index(next_node)
+                intersect_ranges.append((start, stop))
+            else:
+                start = self._start_index(next_node)
+                stop = self._stop_index(next_node)
+                if stop - start <= self._page_size:
+                    maybe_intersect_ranges.append((start, stop))
+                else:
+                    # Partial overlap of interior bounding box, recurse to children
+                    nodes.extend([_right_child(next_node), _left_child(next_node)])
+
+        # Compute max result length
+        max_len = 0
+        for start, stop in intersect_ranges:
+            max_len += stop - start
+        for start, stop in maybe_intersect_ranges:
+            max_len += stop - start
+
+        # Initialize result buffer with max length
+        result = np.zeros(max_len, dtype=np.uint32)
+
+        # populate result from intersect_ranges. In this case, we have certainty that
+        # all bounding boxes in each slice intersect with query_bounds.
+        result_start = 0
+        for start, stop in intersect_ranges:
+            next_slice = self._keys[start:stop]
+            result[result_start:result_start + len(next_slice)] = next_slice
+            result_start += len(next_slice)
+
+        # populate result from maybe_intersect_ranges.  In this case, we need to use
+        # a brute-force check to determine which bounding boxes in the slice intersect
+        # with query_bounds and only include those.
+        for start, stop in maybe_intersect_ranges:
+            next_slice = self._keys[start:stop]
+            bounds_slice = self._bounds[start:stop, :]
+            outside_mask = np.zeros(bounds_slice.shape[0], dtype=np.bool_)
+            for d in range(n):
+                outside_mask |= (bounds_slice[:, d + n] < query_bounds[d])
+                outside_mask |= (bounds_slice[:, d] > query_bounds[d + n])
+
+            next_slice = next_slice[~outside_mask]
+            result[result_start:result_start + len(next_slice)] = next_slice
+            result_start += len(next_slice)
+
+        # Return populated portion of result
+        return result[:result_start]

--- a/spatialpandas/utils.py
+++ b/spatialpandas/utils.py
@@ -1,3 +1,29 @@
+import numpy as np
 from numba import jit
 
 ngjit = jit(nopython=True, nogil=True)
+
+
+@ngjit
+def _data2coord(vals, val_range, n):
+    """
+    Convert an array of values from continuous data coordinates to discrete
+    integer coordinates
+
+    Args:
+        vals: Array of continuous data coordinate to be converted to discrete
+            integer coordinates
+        val_range: Tuple of start (val_range[0]) and stop (val_range[1]) range in
+            continuous data coordinates
+        n: The integer number of discrete distance coordinates
+
+    Returns:
+        unsigned integer array of discrete coordinates
+    """
+    x_width = val_range[1] - val_range[0]
+    res = ((vals - val_range[0]) * (n / x_width)).astype(np.int64)
+
+    # clip
+    res[res < 0] = 0
+    res[res > n - 1] = n - 1
+    return res

--- a/tests/spatialindex/hilbert_curve.py
+++ b/tests/spatialindex/hilbert_curve.py
@@ -1,0 +1,67 @@
+from hilbertcurve.hilbertcurve import HilbertCurve
+from hypothesis import given
+import hypothesis.strategies as st
+from hypothesis import settings
+from itertools import product
+import numpy as np
+
+# ### hypothesis settings ###
+from spatialpandas.spatialindex.hilbert_curve import (
+    coordinates_from_distances, distances_from_coordinates,
+    distance_from_coordinate, coordinate_from_distance)
+
+hyp_settings = settings(deadline=None)
+
+# ### strategies ###
+st_p = st.integers(min_value=1, max_value=5)
+st_n = st.integers(min_value=1, max_value=3)
+
+# ### Hypothesis tests ###
+@given(st_p, st_n)
+@hyp_settings
+def test_coordinates_from_distance(p, n):
+    # Build vector of possible distances
+    distances = np.arange(2 ** (n * p), dtype=np.int64)
+
+    # Compute coordinates as vector result
+    vector_result = coordinates_from_distances(p, n, distances)
+
+    # Compare with reference
+    reference_hc = HilbertCurve(p, n)
+    for i, distance in enumerate(distances):
+        # Reference
+        expected = tuple(reference_hc.coordinates_from_distance(distance))
+
+        # Scalar result
+        scalar_result = tuple(coordinate_from_distance(p, n, distance))
+        assert scalar_result == expected
+
+        # Vector result
+        assert tuple(vector_result[i, :]) == expected
+
+
+@given(st_p, st_n)
+@hyp_settings
+def test_distance_from_coordinates(p, n):
+    side_len = 2 ** p
+
+    # build matrix of all possible coordinate
+    coords = np.array(list(product(range(side_len), repeat=n)))
+
+    # Compute distances as vector result
+    vector_result = distances_from_coordinates(p, coords)
+
+    # Compare with reference
+    reference_hc = HilbertCurve(p, n)
+    for i in range(coords.shape[0]):
+        coord = coords[i, :]
+
+        # Reference
+        expected = reference_hc.distance_from_coordinates(coord)
+
+        # Compute scalar distance and compare
+        scalar_result = distance_from_coordinate(p, coord)
+        assert scalar_result == expected
+
+        # Compare with vector distance compute above
+        assert vector_result[i] == expected

--- a/tests/spatialindex/rtree.py
+++ b/tests/spatialindex/rtree.py
@@ -1,0 +1,163 @@
+from hypothesis import given
+import hypothesis.strategies as st
+from hypothesis import settings
+from hypothesis.extra.numpy import arrays
+import numpy as np
+from spatialpandas.spatialindex import HilbertRtree
+import pickle
+
+# ### hypothesis settings ###
+hyp_settings = settings(deadline=None)
+
+
+# ### Custom strategies ###
+
+@st.composite
+def st_bounds(draw, n_min=1, n_max=3):
+    n = draw(st.integers(min_value=n_min, max_value=n_max))
+    dim_starts = [draw(st.floats(0, 10**(i + 1) - 1)) for i in range(n)]
+    dim_widths = [draw(st.floats(0, 10 ** i)) for i in range(n)]
+    dim_ends = [s + w for s, w in zip(dim_starts, dim_widths)]
+    return tuple(dim_starts + dim_ends)
+
+
+@st.composite
+def st_bounds_array(draw, n_min=1, n_max=3, min_size=1, max_size=1000):
+    n = draw(st.integers(min_value=n_min, max_value=n_max))
+    size = draw(st.integers(min_value=min_size, max_value=max_size))
+
+    dim_starts = draw(
+        arrays(elements=st.floats(0, 9), shape=(size, n), dtype='float64')
+    )
+    dim_widths = draw(
+        arrays(elements=st.floats(0, 1), shape=(size, n), dtype='float64')
+    )
+    dim_ends = dim_starts + dim_widths
+    bounds_array = np.concatenate([dim_starts, dim_ends], axis=1)
+    return bounds_array
+
+
+st_page_size = st.integers(min_value=-1, max_value=1000000)
+
+# ### Test custom strategies ###
+@given(st_bounds())
+def test_bounds_generation(bounds):
+    assert len(bounds) % 2 == 0
+    n = len(bounds) // 2
+    for d in range(n):
+        assert bounds[d + n] >= bounds[d]
+
+
+@given(st_bounds_array())
+def test_bounds_array_generation(bounds_array):
+    assert bounds_array.shape[1] % 2 == 0
+    n = bounds_array.shape[1] // 2
+    for d in range(n):
+        assert np.all(bounds_array[:, d + n] >= bounds_array[:, d])
+
+
+# ### utilities ###
+def rtree_intersection(rt, bounds):
+    return set(rt.intersection(np.array(bounds)))
+
+
+def intersects_bruteforce(query_bounds, bounds):
+    if len(bounds) == 0:
+        return set()
+
+    outside_mask = np.zeros(bounds.shape[0], dtype=np.bool_)
+    n = bounds.shape[1] // 2
+    for d in range(n):
+        outside_mask |= (bounds[:, d + n] < query_bounds[d])
+        outside_mask |= (bounds[:, d] > query_bounds[d + n])
+
+    return set(np.nonzero(~outside_mask)[0])
+
+
+# ### Hypothesis tests ###
+@given(st_bounds_array(), st_page_size)
+@hyp_settings
+def test_rtree_query_input_bounds(bounds_array, page_size):
+    # Build rtree
+    rt = HilbertRtree(bounds_array, page_size=page_size)
+
+    # query with bounds array, these were the input
+    for i in range(bounds_array.shape[0]):
+        b = bounds_array[i, :]
+        intersected = set(rt.intersection(np.array(b)))
+
+        # Should at least select itself
+        assert i in intersected
+
+        # Compare to brute force implementation
+        assert intersected == intersects_bruteforce(b, bounds_array)
+
+
+@given(
+    st_bounds_array(n_min=2, n_max=2),
+    st_bounds_array(n_min=2, n_max=2, min_size=10),
+    st_page_size
+)
+@hyp_settings
+def test_rtree_query_different_bounds_2d(bounds_array, query_array, page_size):
+    # Build rtree
+    rt = HilbertRtree(bounds_array, page_size=page_size)
+
+    # query with query array
+    for i in range(query_array.shape[0]):
+        b = query_array[i, :]
+        intersected = set(rt.intersection(np.array(b)))
+
+        # Compare to brute force implementation
+        assert intersected == intersects_bruteforce(b, bounds_array)
+
+
+@given(st_bounds_array(), st_page_size)
+@hyp_settings
+def test_rtree_query_all(bounds_array, page_size):
+    # Build rtree
+    rt = HilbertRtree(bounds_array, page_size=page_size)
+
+    # query with query array
+    n = bounds_array.shape[1] // 2
+    b_mins = bounds_array[:, :n].min(axis=0)
+    b_maxes = bounds_array[:, n:].max(axis=0)
+    b = np.concatenate([b_mins, b_maxes])
+    intersected = set(rt.intersection(np.array(b)))
+
+    # All indices should be selected
+    assert intersected == set(range(bounds_array.shape[0]))
+
+
+@given(st_bounds_array(), st_page_size)
+@hyp_settings
+def test_rtree_query_none(bounds_array, page_size):
+    # Build rtree
+    rt = HilbertRtree(bounds_array, page_size=page_size)
+
+    # query with query array
+    n = bounds_array.shape[1] // 2
+    b = ([11] * n) + ([100] * n)
+    intersected = set(rt.intersection(np.array(b)))
+
+    # Nothing should be selected
+    assert intersected == set()
+
+
+@given(st_bounds_array(), st_page_size)
+@hyp_settings
+def test_rtree_query_input_bounds_pickle(bounds_array, page_size):
+    # Build rtree
+    rt = HilbertRtree(bounds_array, page_size=page_size)
+
+    # Serialize uninitialized rtree
+    rt2 = pickle.loads(pickle.dumps(rt))
+    rt2_result = set(rt2.intersection(bounds_array[0, :]))
+
+    # Call intersection to construct numba rtree
+    rt_result = set(rt.intersection(bounds_array[0, :]))
+
+    # Serialize initialized rtree
+    rt3 = pickle.loads(pickle.dumps(rt))
+    rt3_result = set(rt3.intersection(bounds_array[0, :]))
+    assert rt_result == rt2_result and rt_result == rt3_result


### PR DESCRIPTION
### Overview
This PR provides a numba accelerated implementation of a Hilbert R-tree. See https://en.wikipedia.org/wiki/Hilbert_R-tree for more info on the Hilbert R-tree.

This implementation stores the R-tree as an array representation of a binary tree. See https://en.wikipedia.org/wiki/Binary_tree#Arrays for more info on the array representation of a binary tree. This representation was selected because it is very memory efficient for read-only binary trees.

### Motivation
Future PRs will use this functionality to provide numba implementations of spatial indexing and spatial joins at the pandas and Dask data frame level.

### Benchmarking
I benchmarked this implementation against the `rtree` package in the notebook at https://anaconda.org/jonmmease/spatialpandas_hilbertrtree_benchmarking_pr/notebook.  Both the R-tree creation and query times are somewhat (and sometimes significantly) faster than the equivalent operations using the `rtree` package.

cc @brendancol



