### PR TITLE
Add GeoSeries, GeoDataFrame, DaskGeoSeries, and DaskGeoDataFrame classes

### DIFF
--- a/spatialpandas/__init__.py
+++ b/spatialpandas/__init__.py
@@ -1,2 +1,11 @@
 from . import geometry
 from . import spatialindex
+from .geoseries import GeoSeries
+from .geodataframe import GeoDataFrame
+try:
+    import dask.dataframe
+    # Import to trigger registration of types with Dask
+    import spatialpandas.dask
+except ImportError:
+    # Dask dataframe not available
+    pass

--- a/spatialpandas/dask.py
+++ b/spatialpandas/dask.py
@@ -1,0 +1,157 @@
+import dask.dataframe as dd
+
+from spatialpandas.geometry.base import _BaseCoordinateIndexer
+from spatialpandas.spatialindex import HilbertRtree
+from .geoseries import GeoSeries
+from .geodataframe import GeoDataFrame
+from dask.dataframe.core import get_parallel_type
+from dask.dataframe.utils import make_meta, meta_nonempty, make_array_nonempty
+import pandas as pd
+import numpy as np
+
+
+class DaskGeoSeries(dd.Series):
+    def __init__(self, dsk, name, meta, divisions, *args, **kwargs):
+        super(DaskGeoSeries, self).__init__(dsk, name, meta, divisions)
+
+        # Init backing properties
+        self._partition_bounds = None
+        self._partition_sindex = None
+
+    @property
+    def bounds(self):
+        return self.map_partitions(lambda s: s.bounds)
+
+    @property
+    def total_bounds(self):
+        partition_bounds = self.partition_bounds
+        return (
+            np.nanmin(partition_bounds['x0']),
+            np.nanmin(partition_bounds['y0']),
+            np.nanmax(partition_bounds['x1']),
+            np.nanmax(partition_bounds['y1']),
+        )
+
+    @property
+    def partition_bounds(self):
+        if self._partition_bounds is None:
+            self._partition_bounds = self.map_partitions(
+                lambda s: pd.DataFrame(
+                    [s.total_bounds], columns=['x0', 'y0', 'x1', 'y1']
+                )
+            ).compute().reset_index(drop=True)
+            self._partition_bounds.index.name = 'partition'
+        return self._partition_bounds
+
+    @property
+    def area(self):
+        return self.map_partitions(lambda s: s.area)
+
+    @property
+    def length(self):
+        return self.map_partitions(lambda s: s.length)
+
+    @property
+    def partition_sindex(self):
+        if self._partition_sindex is None:
+            self._partition_sindex = HilbertRtree(self.partition_bounds.values)
+        return self._partition_sindex
+
+    @property
+    def cx(self):
+        return _DaskCoordinateIndexer(self, self.partition_sindex)
+
+    def intersects_bounds(self, bounds):
+        return self.map_partitions(lambda s: s.intersects_bounds(bounds))
+
+
+@make_meta.register(GeoSeries)
+def make_meta_series(s, index=None):
+    result = s.head(0)
+    if index is not None:
+        result = result.reindex(index[:0])
+    return result
+
+
+@meta_nonempty.register(GeoSeries)
+def meta_nonempty_series(s, index=None):
+    return GeoSeries(make_array_nonempty(s.dtype), index=index)
+
+
+@get_parallel_type.register(GeoSeries)
+def get_parallel_type_dataframe(df):
+    return DaskGeoSeries
+
+
+class DaskGeoDataFrame(dd.DataFrame):
+    def __init__(self, dsk, name, meta, divisions):
+        super().__init__(dsk, name, meta, divisions)
+        self._partition_sindex = None
+
+    @property
+    def geometry(self):
+        # Use self._meta.geometry.name rather than self._meta._geometry so that an
+        # infomative error message is raised if there is no valid geometry column
+        return self[self._meta.geometry.name]
+
+    def set_geometry(self, geometry):
+        if geometry != self._meta._geometry:
+            # Clear spatial index
+            self._partition_sindex = None
+            return self.map_partitions(lambda df: df.set_geometry(geometry))
+        else:
+            return self
+
+    @property
+    def partition_sindex(self):
+        if self._partition_sindex is None:
+            self._partition_sindex = self.geometry.partition_sindex
+        return self._partition_sindex
+
+    @property
+    def cx(self):
+        return _DaskCoordinateIndexer(self, self.partition_sindex)
+
+
+@make_meta.register(GeoDataFrame)
+def make_meta_dataframe(df, index=None):
+    result = df.head(0)
+    if index is not None:
+        result = result.reindex(index[:0])
+    return result
+
+
+@meta_nonempty.register(GeoDataFrame)
+def meta_nonempty_dataframe(df, index=None):
+    return GeoDataFrame(meta_nonempty(pd.DataFrame(df.head(0))))
+
+
+@get_parallel_type.register(GeoDataFrame)
+def get_parallel_type_series(s):
+    return DaskGeoDataFrame
+
+
+class _DaskCoordinateIndexer(_BaseCoordinateIndexer):
+    def __init__(self, obj, sindex):
+        super(_DaskCoordinateIndexer, self).__init__(sindex)
+        self._obj = obj
+
+    def _perform_get_item(self, covers_inds, overlaps_inds, x0, x1, y0, y1):
+        covers_inds = set(covers_inds)
+        overlaps_inds = set(overlaps_inds)
+        all_partition_inds = sorted(covers_inds.union(overlaps_inds))
+        if len(all_partition_inds) == 0:
+            # No partitions intersect with query region, return empty result
+            return dd.from_pandas(self._obj._meta, npartitions=1)
+
+        result = self._obj.partitions[all_partition_inds]
+
+        def map_fn(df, ind):
+            if ind.iloc[0] in overlaps_inds:
+                return df.cx[x0:x1, y0:y1]
+            else:
+                return df
+        return result.map_partitions(
+            map_fn,
+            pd.Series(all_partition_inds, index=result.divisions[:-1]),
+        )

--- a/spatialpandas/geodataframe.py
+++ b/spatialpandas/geodataframe.py
@@ -4,6 +4,14 @@ from .geoseries import GeoSeries
 from ._optional_imports import gp
 
 
+def _maybe_geo_frame(data, **kwargs):
+    try:
+        return GeoDataFrame(data, **kwargs)
+    except ValueError:
+        # No geometry compatible columns
+        return pd.DataFrame(data, **kwargs)
+
+
 class GeoDataFrame(pd.DataFrame):
     # properties to propagate
     _metadata = ['_geometry']
@@ -38,7 +46,7 @@ class GeoDataFrame(pd.DataFrame):
 
     @property
     def _constructor(self):
-        return GeoDataFrame
+        return _maybe_geo_frame
 
     @property
     def _constructor_sliced(self):

--- a/spatialpandas/geodataframe.py
+++ b/spatialpandas/geodataframe.py
@@ -1,0 +1,97 @@
+import pandas as pd
+from .geometry import GeometryDtype
+from .geoseries import GeoSeries
+from ._optional_imports import gp
+
+
+class GeoDataFrame(pd.DataFrame):
+    # properties to propagate
+    _metadata = ['_geometry']
+
+    def __init__(self, data=None, index=None, geometry=None, **kwargs):
+        # Call pandas constructor
+        super().__init__(data, index=index, **kwargs)
+
+        # Replace pd.Series of GeometryArrays with GeoSeries.
+        first_geometry_col = None
+        for col in self.columns:
+            if (isinstance(self[col].dtype, GeometryDtype) or
+                    gp and isinstance(self[col].dtype, gp.array.GeometryDtype)):
+                self[col] = GeoSeries(self[col])
+                first_geometry_col = first_geometry_col or col
+
+        if first_geometry_col is None:
+            raise ValueError(
+                "A spatialpandas GeoDataFrame must contain at least one spatialpandas "
+                "GeometryArray column"
+            )
+
+        if geometry is None:
+            if isinstance(data, GeoDataFrame) and data._has_valid_geometry():
+                geometry = data._geometry
+            else:
+                geometry = first_geometry_col
+
+        self._geometry = None
+        if geometry is not None:
+            self.set_geometry(geometry, inplace=True)
+
+    @property
+    def _constructor(self):
+        return GeoDataFrame
+
+    @property
+    def _constructor_sliced(self):
+        from spatialpandas.geoseries import _maybe_geo_series
+        return _maybe_geo_series
+
+    def set_geometry(self, geometry, inplace=False):
+        if (geometry not in self or
+                not isinstance(self[geometry].dtype, GeometryDtype)):
+            raise ValueError(
+                "The geometry argument must be the name of a spatialpandas "
+                "geometry column in the spatialpandas GeoDataFrame"
+            )
+
+        if inplace:
+            self._geometry = geometry
+            return self
+        else:
+            return GeoDataFrame(self, geometry=geometry)
+
+    def _has_valid_geometry(self):
+        if (self._geometry is not None and
+                self._geometry in self and
+                isinstance(self[self._geometry].dtype, GeometryDtype)):
+            return True
+        else:
+            return False
+
+    @property
+    def geometry(self):
+        if not self._has_valid_geometry():
+            raise ValueError(
+                "GeoDataFrame has no active geometry column.\n"
+                "The active geometry column should be set using the set_geometry "
+                "method."
+            )
+
+        return self[self._geometry]
+
+    def to_geopandas(self):
+        from geopandas import GeoDataFrame as gp_GeoDataFrame
+        gdf = gp_GeoDataFrame(
+            {col: s.array.to_geopandas() if isinstance(s.dtype, GeometryDtype) else s
+             for col, s in self.items()},
+            index=self.index,
+        )
+        if self._has_valid_geometry():
+            gdf.set_geometry(self._geometry, inplace=True)
+        return gdf
+
+    @property
+    def cx(self):
+        from .geometry.base import _CoordinateIndexer
+        return _CoordinateIndexer(
+            self.geometry.array, parent=self
+        )

--- a/spatialpandas/geometry/base.py
+++ b/spatialpandas/geometry/base.py
@@ -7,7 +7,7 @@ import re
 
 from numba import jit, prange
 from pandas.api.extensions import ExtensionArray, ExtensionDtype
-from pandas.core.dtypes.inference import is_array_like
+from pandas.api.types import is_array_like
 
 from ._algorithms.bounds import (
     total_bounds_interleaved, total_bounds_interleaved_1d, bounds_interleaved

--- a/spatialpandas/geometry/line.py
+++ b/spatialpandas/geometry/line.py
@@ -64,7 +64,7 @@ or LinearRing""".format(typ=type(shape).__name__))
 
     @property
     def length(self):
-        return compute_line_length(self.flat_values, self.flat_inner_offsets)
+        return compute_line_length(self.buffer_values, self.buffer_inner_offsets)
 
     @property
     def area(self):
@@ -73,10 +73,10 @@ or LinearRing""".format(typ=type(shape).__name__))
     def intersects_bounds(self, bounds):
         x0, y0, x1, y1 = bounds
         result = np.zeros(1, dtype=np.bool_)
-        offsets = self.flat_outer_offsets
+        offsets = self.buffer_outer_offsets
         lines_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, offsets[:-1], offsets[1:], result
+            self.buffer_values, offsets[:-1], offsets[1:], result
         )
         return result[0]
 
@@ -124,7 +124,7 @@ class LineArray(GeometryArray):
 
     def intersects_bounds(self, bounds, inds=None):
         x0, y0, x1, y1 = bounds
-        offsets = self.flat_outer_offsets
+        offsets = self.buffer_outer_offsets
         start_offsets0 = offsets[:-1]
         stop_offsets0 = offsets[1:]
         if inds is not None:
@@ -134,7 +134,7 @@ class LineArray(GeometryArray):
         result = np.zeros(len(stop_offsets0), dtype=np.bool_)
         lines_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets0, stop_offsets0, result
+            self.buffer_values, start_offsets0, stop_offsets0, result
         )
         return result
 

--- a/spatialpandas/geometry/multiline.py
+++ b/spatialpandas/geometry/multiline.py
@@ -76,7 +76,7 @@ Received invalid value of type {typ}. Must be an instance of MultiLineString
 
     @property
     def length(self):
-        return compute_line_length(self.flat_values, self.flat_inner_offsets)
+        return compute_line_length(self.buffer_values, self.buffer_inner_offsets)
 
     @property
     def area(self):
@@ -84,13 +84,13 @@ Received invalid value of type {typ}. Must be an instance of MultiLineString
 
     def intersects_bounds(self, bounds):
         x0, y0, x1, y1 = bounds
-        offsets = self.flat_outer_offsets
+        offsets = self.buffer_outer_offsets
         start_offsets = offsets[:-1]
         stop_offstes = offsets[1:]
         result = np.zeros(len(start_offsets), dtype=np.bool_)
         lines_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets, stop_offstes, result
+            self.buffer_values, start_offsets, stop_offstes, result
         )
         return result.any()
 
@@ -148,7 +148,7 @@ class MultiLineArray(GeometryArray):
         result = np.zeros(len(start_offsets0), dtype=np.bool_)
         multilines_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets0, stop_offsets0, offsets1, result
+            self.buffer_values, start_offsets0, stop_offsets0, offsets1, result
         )
         return result
 

--- a/spatialpandas/geometry/multipoint.py
+++ b/spatialpandas/geometry/multipoint.py
@@ -69,10 +69,10 @@ or MultiPoint""".format(typ=type(shape).__name__))
     def intersects_bounds(self, bounds):
         x0, y0, x1, y1 = bounds
         result = np.zeros(1, dtype=np.bool_)
-        offsets = self.flat_outer_offsets
+        offsets = self.buffer_outer_offsets
         multipoints_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, offsets[:-1], offsets[1:], result
+            self.buffer_values, offsets[:-1], offsets[1:], result
         )
         return result[0]
 
@@ -110,7 +110,7 @@ class MultiPointArray(GeometryArray):
 
     def intersects_bounds(self, bounds, inds=None):
         x0, y0, x1, y1 = bounds
-        offsets0 = self.flat_outer_offsets
+        offsets0 = self.buffer_outer_offsets
         start_offsets0 = offsets0[:-1]
         stop_offsets0 = offsets0[1:]
 
@@ -121,7 +121,7 @@ class MultiPointArray(GeometryArray):
         result = np.zeros(len(start_offsets0), dtype=np.bool_)
         multipoints_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets0, stop_offsets0, result
+            self.buffer_values, start_offsets0, stop_offsets0, result
         )
         return result
 

--- a/spatialpandas/geometry/multipolygon.py
+++ b/spatialpandas/geometry/multipolygon.py
@@ -99,11 +99,11 @@ Received invalid value of type {typ}. Must be an instance of Polygon or MultiPol
 
     @property
     def length(self):
-        return compute_line_length(self.flat_values, self.flat_inner_offsets)
+        return compute_line_length(self.buffer_values, self.buffer_inner_offsets)
 
     @property
     def area(self):
-        return compute_area(self.flat_values, self.flat_inner_offsets)
+        return compute_area(self.buffer_values, self.buffer_inner_offsets)
 
     def intersects_bounds(self, bounds):
         x0, y0, x1, y1 = bounds
@@ -111,7 +111,7 @@ Received invalid value of type {typ}. Must be an instance of Polygon or MultiPol
         offsets1, offsets2 = self.buffer_offsets
         offsets0 = np.array([0, len(offsets1) - 1], dtype=np.uint32)
         multipolygons_intersect_bounds(
-            float(x0), float(y0), float(x1), float(y1), self.flat_values,
+            float(x0), float(y0), float(x1), float(y1), self.buffer_values,
             offsets0[:-1], offsets0[1:], offsets1, offsets2, result
         )
         return result[0]
@@ -193,7 +193,7 @@ class MultiPolygonArray(GeometryArray):
 
         result = np.zeros(len(start_offsets0), dtype=np.bool_)
         multipolygons_intersect_bounds(
-            float(x0), float(y0), float(x1), float(y1), self.flat_values,
+            float(x0), float(y0), float(x1), float(y1), self.buffer_values,
             start_offsets0, stop_offsets0, offsets1, offsets2, result
         )
         return result

--- a/spatialpandas/geometry/polygon.py
+++ b/spatialpandas/geometry/polygon.py
@@ -91,21 +91,21 @@ Received invalid value of type {typ}. Must be an instance of Polygon
 
     @property
     def length(self):
-        return compute_line_length(self.flat_values, self.flat_inner_offsets)
+        return compute_line_length(self.buffer_values, self.buffer_inner_offsets)
 
     @property
     def area(self):
-        return compute_area(self.flat_values, self.flat_inner_offsets)
+        return compute_area(self.buffer_values, self.buffer_inner_offsets)
 
     def intersects_bounds(self, bounds):
         x0, y0, x1, y1 = bounds
         result = np.zeros(1, dtype=np.bool_)
-        offsets1 = self.flat_inner_offsets
+        offsets1 = self.buffer_inner_offsets
         start_offsets0 = np.array([0], dtype=np.uint32)
         stop_offsets0 = np.array([len(offsets1) - 1], dtype=np.uint32)
         polygons_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets0, stop_offsets0, offsets1, result
+            self.buffer_values, start_offsets0, stop_offsets0, offsets1, result
         )
         return result[0]
 
@@ -183,7 +183,7 @@ class PolygonArray(GeometryArray):
         result = np.zeros(len(start_offsets0), dtype=np.bool_)
         polygons_intersect_bounds(
             float(x0), float(y0), float(x1), float(y1),
-            self.flat_values, start_offsets0, stop_offsets0, offsets1, result
+            self.buffer_values, start_offsets0, stop_offsets0, offsets1, result
         )
         return result
 

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -1,0 +1,78 @@
+import pandas as pd
+
+from spatialpandas.geometry import GeometryDtype
+from .geometry.base import Geometry
+
+
+def _maybe_geo_series(data, **kwargs):
+    if isinstance(getattr(data, 'dtype', None), GeometryDtype):
+        return GeoSeries(data, **kwargs)
+    else:
+        return pd.Series(data, **kwargs)
+
+
+class GeoSeries(pd.Series):
+    def __init__(self, data, index=None, name=None, dtype=None, **kwargs):
+        from .geometry.base import to_geometry_array
+        # Handle scalar geometry with index
+        if isinstance(data, Geometry):
+            n = len(index) if index is not None else 1
+            data = [data] * n
+
+        if index is None and hasattr(data, 'dtype'):
+            # Try to get input index from Series-like object
+            index = getattr(data, 'index', None)
+        if name is None:
+            name = getattr(data, 'name', None)
+
+        # Normalize dtype from string
+        if dtype is not None:
+            dtype = pd.array([], dtype=dtype).dtype
+
+        data = to_geometry_array(data, dtype)
+        super(GeoSeries, self).__init__(data, index=index, name=name, **kwargs)
+
+    @property
+    def _constructor(self):
+        return _maybe_geo_series
+
+    @property
+    def _constructor_expanddim(self):
+        from .geodataframe import GeoDataFrame
+        return GeoDataFrame
+
+    @property
+    def bounds(self):
+        return pd.DataFrame(
+            self.array.bounds, columns=['x0', 'y0', 'x1', 'y1'], index=self.index
+        )
+
+    @property
+    def total_bounds(self):
+        return self.array.total_bounds
+
+    @property
+    def area(self):
+        return pd.Series(self.array.area, index=self.index)
+
+    @property
+    def length(self):
+        return pd.Series(self.array.length, index=self.index)
+
+    @property
+    def sindex(self):
+        return self.array.sindex
+
+    @property
+    def cx(self):
+        from .geometry.base import _CoordinateIndexer
+        return _CoordinateIndexer(self.array, parent=self)
+
+    def intersects_bounds(self, bounds):
+        return pd.Series(
+            self.array.intersects_bounds(bounds), index=self.index
+        )
+
+    def to_geopandas(self):
+        from geopandas import GeoSeries
+        return GeoSeries(self.array.to_geopandas(), index=self.index)

--- a/spatialpandas/geoseries.py
+++ b/spatialpandas/geoseries.py
@@ -59,6 +59,12 @@ class GeoSeries(pd.Series):
     def length(self):
         return pd.Series(self.array.length, index=self.index)
 
+    def hilbert_distance(self, total_bounds=None, p=10):
+        return pd.Series(
+            self.array.hilbert_distance(total_bounds=total_bounds, p=p),
+            index=self.index
+        )
+
     @property
     def sindex(self):
         return self.array.sindex

--- a/spatialpandas/io/__init__.py
+++ b/spatialpandas/io/__init__.py
@@ -1,0 +1,1 @@
+from .parquet import read_parquet, read_parquet_dask, to_parquet, to_parquet_dask

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -1,0 +1,175 @@
+import copy
+import json
+import os
+
+import pandas as pd
+from dask.dataframe import to_parquet as dd_to_parquet, read_parquet as dd_read_parquet
+
+from pandas.io.parquet import (
+    to_parquet as pd_to_parquet, read_parquet as pd_read_parquet
+)
+import pyarrow as pa
+from pyarrow import parquet as pq
+
+from spatialpandas import GeoDataFrame
+from spatialpandas.dask import DaskGeoDataFrame
+from spatialpandas.geometry.base import to_geometry_array, GeometryDtype
+from spatialpandas.geometry import (
+    MultiPointDtype, RingDtype, LineDtype,
+    MultiLineDtype, PolygonDtype, MultiPolygonDtype,
+    GeometryDtype)
+
+_geometry_dtypes = [
+    MultiPointDtype, RingDtype, LineDtype, MultiLineDtype, PolygonDtype, MultiPolygonDtype
+]
+
+
+def _import_geometry_columns(df, geom_cols):
+    new_cols = {}
+    for col, type_str in geom_cols.items():
+        if col in df and not isinstance(df.dtypes[col], GeometryDtype):
+            new_cols[col] = to_geometry_array(df[col], dtype=type_str)
+
+    return df.assign(**new_cols)
+
+
+def _load_parquet_pandas_metadata(path):
+    if not os.path.exists(path):
+        raise ValueError("Path not found: " + path)
+
+    if os.path.isdir(path):
+        pqds = pa.parquet.ParquetDataset(path)
+        metadata = pqds.common_metadata.metadata
+    else:
+        pf = pa.parquet.ParquetFile(path)
+        metadata = pf.metadata.metadata
+
+    return json.loads(
+        metadata.get(b'pandas', b'{}').decode('utf')
+    )
+
+
+def _get_geometry_columns(pandas_metadata):
+    columns = pandas_metadata.get('columns', [])
+    geom_cols = {}
+    for col in columns:
+        type_string = col.get('numpy_type', None)
+        is_geom_col = False
+        for geom_type in _geometry_dtypes:
+            try:
+                geom_type.construct_from_string(type_string)
+                is_geom_col = True
+            except TypeError:
+                pass
+        if is_geom_col:
+            geom_cols[col["name"]] = col["numpy_type"]
+
+    return geom_cols
+
+
+def to_parquet(
+    df,
+    fname,
+    compression="snappy",
+    index=None,
+    **kwargs
+):
+    # Standard pandas to_parquet with pyarrow engine
+    pd_to_parquet(
+        df, fname, engine="pyarrow", compression=compression, index=index, **kwargs
+    )
+
+
+def read_parquet(path, columns=None):
+    # Load using standard pandas read_parquet
+    result = pd_read_parquet(path, engine="auto", columns=columns)
+
+    # Import geometry columns, not needed for pyarrow >= 0.16
+    metadata = _load_parquet_pandas_metadata(path)
+    geom_cols = _get_geometry_columns(metadata)
+    if geom_cols:
+        result = _import_geometry_columns(result, geom_cols)
+
+    # Return result
+    return GeoDataFrame(result)
+
+
+def to_parquet_dask(ddf, path, compression="default", storage_options=None, **kwargs):
+    assert isinstance(ddf, DaskGeoDataFrame)
+
+    dd_to_parquet(
+        ddf, path, engine="pyarrow", compression=compression,
+        storage_options=storage_options, **kwargs
+    )
+
+    # Write partition bounding boxes to the _metadata file
+    partition_bounds = {}
+    for series_name in ddf.columns:
+        series = ddf[series_name]
+        if isinstance(series.dtype, GeometryDtype):
+            partition_bounds[series_name] = series.partition_bounds.to_dict()
+
+    spatial_metadata = {'partition_bounds': partition_bounds}
+    b_spatial_metadata = json.dumps(spatial_metadata).encode('utf')
+
+    pqds = pq.ParquetDataset(path)
+    all_metadata = copy.copy(pqds.metadata.metadata)
+    all_metadata[b'spatialpandas'] = b_spatial_metadata
+    new_schema = pqds.metadata.schema.to_arrow_schema().with_metadata(all_metadata)
+    pq.write_metadata(new_schema, pqds.metadata_path)
+
+
+def read_parquet_dask(path, columns=None, categories=None, storage_options=None, **kwargs):
+    result = dd_read_parquet(
+        path,
+        columns=columns,
+        categories=categories,
+        storage_options=storage_options,
+        engine="pyarrow",
+        **kwargs
+    )
+
+    # Import geometry columns, not needed for pyarrow >= 0.16
+    metadata = _load_parquet_pandas_metadata(path)
+    geom_cols = _get_geometry_columns(metadata)
+    if not geom_cols:
+        # No geometry columns found, regular DaskDataFrame
+        return result
+
+    # Convert Dask DataFrame to DaskGeoDataFrame and the partitions and metadata
+    # to GeoDataFrames
+    result = result.map_partitions(
+        lambda df: GeoDataFrame(_import_geometry_columns(df, geom_cols)),
+    )
+
+    result = DaskGeoDataFrame(
+        result.dask,
+        result._name,
+        GeoDataFrame(_import_geometry_columns(result._meta, geom_cols)),
+        result.divisions,
+    )
+    # Load bounding box info from _metadata
+    pqds = pq.ParquetDataset(path)
+    if b'spatialpandas' in pqds.metadata.metadata:
+        spatial_metadata = json.loads(
+            pqds.metadata.metadata[b'spatialpandas'].decode('utf')
+        )
+        if "partition_bounds" in spatial_metadata:
+            partition_bounds = {}
+            for name in spatial_metadata['partition_bounds']:
+                bounds_df = pd.DataFrame(
+                    spatial_metadata['partition_bounds'][name]
+                )
+
+                # Index labels will be read in as strings.
+                # Here we convert to integers, sort by index, then drop index just in
+                # case the rows got shuffled on read
+                bounds_df = (bounds_df
+                             .set_index(bounds_df.index.astype('int'))
+                             .sort_index()
+                             .reset_index(drop=True))
+                bounds_df.index.name = 'partition'
+
+                partition_bounds[name] = bounds_df
+            result._partition_bounds = partition_bounds
+    return result

--- a/spatialpandas/spatialindex/rtree.py
+++ b/spatialpandas/spatialindex/rtree.py
@@ -64,6 +64,10 @@ class HilbertRtree(object):
 
         See HilbertRtree.__init__ for parameter descriptions
         """
+        # Handle empty bounds array
+        if bounds.size == 0:
+            return bounds, np.zeros(0, dtype=np.int64), bounds
+
         # Init bounds_tree array for storing the binary tree representation
         input_size = bounds.shape[0]
         n = bounds.shape[1] // 2
@@ -97,6 +101,7 @@ class HilbertRtree(object):
 
         # Populate leaves of the tree, one leaf per page. This is layer = tree_depth
         sorted_bounds = bounds[keys, :]
+
         for page in range(num_pages):
             start = page * page_size
             stop = start + page_size
@@ -159,11 +164,10 @@ class HilbertRtree(object):
         if len(bounds.shape) != 2:
             raise ValueError("bounds must be a 2D array")
 
-        if bounds.shape[0] == 0:
-            raise ValueError("The first dimension of bounds must not be empty")
-
-        if bounds.shape[1] % 2 != 0:
-            raise ValueError("The second dimension of bounds must be a multiple of 2")
+        if bounds.shape[1] < 2 or bounds.shape[1] % 2 != 0:
+            raise ValueError(
+                "The second dimension of bounds must be a multiple of 2 and at least 2"
+            )
 
         self._page_size = max(1, page_size)  # 1 is smallest valid page size
         self._numba_rtree = None
@@ -226,11 +230,21 @@ class HilbertRtree(object):
         return self.numba_rtree.covers_overlaps(bounds)
 
     @property
+    def empty(self):
+        """
+        True if the RTree was created with zero bounding boxes
+        """
+        return self.numba_rtree._bounds_tree.shape[0] == 0
+
+    @property
     def total_bounds(self):
         """
         Tuple of the total bounds of all bounding boxes
         """
-        return tuple(self.numba_rtree._bounds_tree[0, :])
+        if not self.empty:
+            return tuple(self.numba_rtree._bounds_tree[0, :])
+        else:
+            return tuple((np.nan,) * self.numba_rtree._bounds_tree.shape[1])
 
 
 _numbartree_spec = [
@@ -339,6 +353,9 @@ class _NumbaRtree(object):
         """
         See HilbertRtree.intersection
         """
+        if self._bounds.size == 0:
+            return np.zeros(0, dtype=np.uint32)
+
         n = len(query_bounds) // 2
         covered_ranges, maybe_intersect_ranges = self._maybe_intersects_ranges(
             query_bounds)
@@ -383,6 +400,9 @@ class _NumbaRtree(object):
         """
         See HilbertRtree.covers_overlaps
         """
+        if self._bounds.size == 0:
+            return np.zeros(0, dtype=np.uint32), np.zeros(0, dtype=np.uint32)
+
         n = len(query_bounds) // 2
         covered_ranges, maybe_intersect_ranges = self._maybe_intersects_ranges(
             query_bounds)

--- a/tests/geometry/algorithms/intersection.py
+++ b/tests/geometry/algorithms/intersection.py
@@ -34,7 +34,7 @@ def test_point_intersects_polygon(sg_polygon, points):
     for r in range(points.shape[0]):
         x, y = points[r, :]
         result = point_intersects_polygon(
-            x, y, polygon.flat_values, polygon.flat_inner_offsets
+            x, y, polygon.buffer_values, polygon.buffer_inner_offsets
         )
 
         expected = sg_polygon.intersects(sg.Point([x, y]))

--- a/tests/geometry/algorithms/measures.py
+++ b/tests/geometry/algorithms/measures.py
@@ -1,0 +1,23 @@
+import numpy as np
+from hypothesis import given
+from spatialpandas.geometry import MultiPolygonArray, PolygonArray
+from tests.geometry.strategies import st_multipolygons_array, hyp_settings, \
+    st_polygons_array
+
+
+@given(st_polygons_array(),)
+@hyp_settings
+def test_polygon_area(gp_polygon):
+    polygons = PolygonArray.from_geopandas(gp_polygon)
+    expected_area = gp_polygon.area
+    area = polygons.area
+    np.testing.assert_allclose(area, expected_area)
+
+
+@given(st_multipolygons_array(),)
+@hyp_settings
+def test_multipolygon_area(gp_multipolygon):
+    multipolygons = MultiPolygonArray.from_geopandas(gp_multipolygon)
+    expected_area = gp_multipolygon.area
+    area = multipolygons.area
+    np.testing.assert_allclose(area, expected_area)

--- a/tests/test_extensionarray.py
+++ b/tests/test_extensionarray.py
@@ -138,7 +138,13 @@ class TestGeometryDtype(eb.BaseDtypeTests):
 
 
 class TestGeometryGetitem(eb.BaseGetitemTests):
-    pass
+    @pytest.mark.skip(reason="non-None fill value not supported")
+    def test_take_non_na_fill_value(self):
+        pass
+
+    @pytest.mark.skip(reason="non-None fill value not supported")
+    def test_reindex_non_na_fill_value(self, data_missing):
+        pass
 
 
 class TestGeometryGroupby(eb.BaseGroupbyTests):

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -1,0 +1,47 @@
+from spatialpandas import GeoDataFrame
+import pandas as pd
+from collections import OrderedDict
+import pytest
+import dask.dataframe as dd
+import dask
+
+dask.config.set(scheduler="single-threaded")
+
+
+@pytest.mark.parametrize('use_dask', [False, True])
+def test_active_geometry(use_dask):
+    gdf = GeoDataFrame(OrderedDict([
+        ('a', [3, 2, 1]),
+        ('points', pd.array([[0, 0, 1, 1], [2, 2, 3, 3], [4, 4]], dtype='multipoint')),
+        ('line', pd.array([[0, 0, 1, 1], [2, 2, 3, 3], [4, 4]], dtype='line')),
+    ]))
+
+    if use_dask:
+        gdf = dd.from_pandas(gdf, npartitions=2)
+
+    # geometry start out as first compatible column in data frame
+    assert gdf.geometry.name == 'points'
+
+    # set_geometry default to copy operation
+    assert gdf.set_geometry('line').geometry.name == 'line'
+    assert gdf.geometry.name == 'points'
+
+    # set_geometry inplace mutates geometry column
+    if use_dask:
+        # inplace not supported for DaskGeoDataFrame
+        gdf = gdf.set_geometry('line')
+    else:
+        gdf.set_geometry('line', inplace=True)
+    assert gdf.geometry.name == 'line'
+
+    # Activate geometry propagates through slicing
+    sliced_gdf = gdf.loc[[0, 2, 1, 0]]
+    assert isinstance(sliced_gdf, type(gdf))
+    assert sliced_gdf.geometry.name == 'line'
+
+    # Select columns not including active geometry
+    selected_gdf = gdf[['a', 'points']]
+    with pytest.raises(ValueError):
+        selected_gdf.geometry
+
+    assert selected_gdf.set_geometry('points').geometry.name == 'points'

--- a/tests/test_geodataframe.py
+++ b/tests/test_geodataframe.py
@@ -1,4 +1,4 @@
-from spatialpandas import GeoDataFrame
+from spatialpandas import GeoDataFrame, GeoSeries
 import pandas as pd
 from collections import OrderedDict
 import pytest
@@ -45,3 +45,17 @@ def test_active_geometry(use_dask):
         selected_gdf.geometry
 
     assert selected_gdf.set_geometry('points').geometry.name == 'points'
+
+
+def test_dataframe_slice_types():
+    gdf = GeoDataFrame({
+        'a': [3, 2, 1],
+        'b': [10, 11, 12],
+        'points': pd.array([[0, 0, 1, 1], [2, 2, 3, 3], [4, 4]], dtype='multipoint'),
+        'line': pd.array([[0, 0, 1, 1], [2, 2, 3, 3], [4, 4]], dtype='line'),
+    })
+
+    assert isinstance(gdf['a'], pd.Series)
+    assert isinstance(gdf['points'], GeoSeries)
+    assert isinstance(gdf[['a', 'b']], pd.DataFrame)
+    assert isinstance(gdf[['a', 'line']], GeoDataFrame)

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -1,0 +1,104 @@
+from hypothesis import given, settings
+import dask.dataframe as dd
+import pandas as pd
+from spatialpandas import GeoSeries, GeoDataFrame
+from spatialpandas.dask import DaskGeoDataFrame
+from tests.geometry.strategies import (
+    st_multipoint_array, st_multiline_array,
+)
+import numpy as np
+from spatialpandas.io import (
+    to_parquet, read_parquet, read_parquet_dask, to_parquet_dask
+)
+
+hyp_settings = settings(deadline=None, max_examples=100)
+
+
+@given(
+    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
+    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+)
+@hyp_settings
+def test_parquet(gp_multipoint, gp_multiline, tmp_path):
+    # Build dataframe
+    n = min(len(gp_multipoint), len(gp_multiline))
+    df = GeoDataFrame({
+        'points': GeoSeries(gp_multipoint[:n]),
+        'lines': GeoSeries(gp_multiline[:n]),
+        'a': list(range(n))
+    })
+
+    path = tmp_path / 'df.parq'
+    to_parquet(df, path)
+    df_read = read_parquet(path)
+    assert isinstance(df_read, GeoDataFrame)
+    assert all(df == df_read)
+
+
+@given(
+    gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
+    gp_multiline=st_multiline_array(min_size=1, geoseries=True),
+)
+@hyp_settings
+def test_parquet_dask(gp_multipoint, gp_multiline, tmp_path):
+    # Build dataframe
+    n = min(len(gp_multipoint), len(gp_multiline))
+    df = GeoDataFrame({
+        'points': GeoSeries(gp_multipoint[:n]),
+        'lines': GeoSeries(gp_multiline[:n]),
+        'a': list(range(n))
+    })
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    path = tmp_path / 'ddf.parq'
+    to_parquet_dask(ddf, path)
+    ddf_read = read_parquet_dask(path)
+
+    # Check type
+    assert isinstance(ddf_read, DaskGeoDataFrame)
+
+    # Check that partition bounds were loaded
+    assert set(ddf_read._partition_bounds) == {'points', 'lines'}
+    pd.testing.assert_frame_equal(
+        ddf['points'].partition_bounds,
+        ddf_read._partition_bounds['points'],
+    )
+    pd.testing.assert_frame_equal(
+        ddf['lines'].partition_bounds,
+        ddf_read._partition_bounds['lines'],
+    )
+
+
+@given(
+    gp_multipoint=st_multipoint_array(min_size=10, max_size=40, geoseries=True),
+    gp_multiline=st_multiline_array(min_size=10, max_size=40, geoseries=True),
+)
+@hyp_settings
+def test_pack_partitions(gp_multipoint, gp_multiline):
+    # Build dataframe
+    n = min(len(gp_multipoint), len(gp_multiline))
+    df = GeoDataFrame({
+        'points': GeoSeries(gp_multipoint[:n]),
+        'lines': GeoSeries(gp_multiline[:n]),
+        'a': list(range(n))
+    }).set_geometry('lines')
+    ddf = dd.from_pandas(df, npartitions=3)
+
+    # Pack partitions
+    ddf_packed = ddf.pack_partitions(npartitions=4)
+
+    # Check the number of partitions
+    assert ddf_packed.npartitions == 4
+
+    # Check that rows are now sorted in order of hilbert distance
+    total_bounds = df.lines.total_bounds
+    hilbert_distances = ddf_packed.lines.map_partitions(
+        lambda s: s.hilbert_distance(total_bounds=total_bounds)
+    ).compute().values
+
+    # Compute expected total_bounds
+    expected_distances = np.sort(
+        df.lines.hilbert_distance(total_bounds=total_bounds).values
+    )
+
+    np.testing.assert_equal(expected_distances, hilbert_distances)


### PR DESCRIPTION
This PR introduces four new classes. `GeoSeries` and `GeoDataFrame` are subclasses of pandas `Series` and `DataFrame` respectively. I used the geopandas class names because I was able to use a subset of the geopandas API in these classes.

The `DaskGeoSeries` and `DaskGeoDataFrame` classes are subclasses of dask `Series` and `DataFrame` respectively.

The `GeoDataFrame` and `DaskGeoDataFrame` classes use the geopandas concept
of an active geometry column to control which column `cx` applies to (discussed below).

The most interesting part part of this PR, in my opinion, is the `cx` indexer on `DaskGeoSeries` and `DaskGeoDataFrame`.   These classes support a distributed `cx` that use a two layer R-tree.
 - A top-level R-tree is used to identify which partitions to include. These partitions are split into partitions that are fully covered by the query region and those that overlap with the query region.
 - Partitions that are fully covered are included in the cx result as-is (no additional filtering is needed).
 - Partitions that overlap with the query region are processed recursively by applying the `cx` operation to each partition, which is also accelerated using the R-tree associated with each partition.

~This PR does *not* include any R-tree packing logic at the partition level. This will come in the next PR, introducing parquet support.  As such, I'm going to hold off on benchmark until that PR.~

As of cb3028d, this PR also includes support for serializing `GeoDataFrame`s and `DaskGeoDataFrame`s to parquet.  For the Dask case, this parquet serialization stores the bounding box information of each partition in the `_metadata`, and these bounding boxes are restored when the file is read.

The `DaskGeoDataFrame.pack_partitions` function sorts and repartitions the data frame based on the Hilbert curve distance of the center of the geometry object in each row.  This causes the bounding boxes of the partitions to have much less overlap than they typically would.
