### PR TITLE
Add fixed length PointArray type

### DIFF
--- a/spatialpandas/geometry/__init__.py
+++ b/spatialpandas/geometry/__init__.py
@@ -5,4 +5,5 @@ from .line import Line, LineArray, LineDtype
 from .multiline import MultiLine, MultiLineArray, MultiLineDtype
 from .multipoint import MultiPoint, MultiPointArray, MultiPointDtype
 from .ring import Ring, RingArray, RingDtype
+from .point import Point, PointArray, PointDtype
 from .base import Geometry, GeometryArray, GeometryDtype, to_geometry_array

--- a/spatialpandas/geometry/basefixed.py
+++ b/spatialpandas/geometry/basefixed.py
@@ -1,0 +1,209 @@
+from __future__ import absolute_import
+from functools import total_ordering
+import pyarrow as pa
+import numpy as np
+
+from spatialpandas.geometry.base import Geometry, GeometryArray, GeometryDtype
+from spatialpandas.geometry.baselist import _lexographic_lt
+from ._algorithms.bounds import (
+    total_bounds_interleaved, total_bounds_interleaved_1d, bounds_interleaved
+)
+
+
+@total_ordering
+class GeometryFixed(Geometry):
+    """
+    Base class for elements of GeometryFixedArray subclasses
+    """
+    def __init__(self, data, dtype=None):
+        super(GeometryFixed, self).__init__(data)
+        self.numpy_dtype = np.dtype(dtype)
+        self.pyarrow_type = pa.from_numpy_dtype(dtype)
+
+    def __lt__(self, other):
+        return _lexographic_lt(self.flat_values, other.flat_values)
+
+    def __len__(self):
+        return 8 * len(self.data.as_py()) // self.pyarrow_type.bit_width
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__, self.flat_values.tolist())
+
+    @property
+    def flat_values(self):
+        return pa.Array.from_buffers(
+            self.pyarrow_type,
+            len(self),
+            buffers=[None, pa.py_buffer(self.data.as_py())]
+        ).to_numpy()
+
+    @classmethod
+    def construct_array_type(cls):
+        return GeometryFixedArray
+
+
+class GeometryFixedArray(GeometryArray):
+    """
+    Base class for geometry arrays that are backed by a pyarrow ListArray.
+    """
+    _element_type = GeometryFixed
+    _element_len = 2
+
+    @classmethod
+    def _arrow_type_from_numpy_element_dtype(cls, dtype):
+        # Scalar element dtype
+        arrow_dtype = pa.from_numpy_dtype(dtype)
+        return pa.binary(arrow_dtype.bit_width // 8)
+
+    def _numpy_element_dtype_from_arrow_type(self, pyarrow_type):
+        return self._numpy_dtype
+
+    # Constructor
+    def __init__(self, array, dtype=None):
+
+        def invalid_array():
+            err_msg = (
+                "Invalid array with type {typ}\n"
+                "A {cls} may be constructed from:\n"
+                "    - A 1-d array with length divisible by {n} of interleaved\n"
+                "      x y coordinates\n"
+                "    - A tuple of {n} 1-d arrays\n"
+                "    - A pyarrow.FixedSizeBinaryArray. In this case the dtype\n"
+                "      argument must also be specified"
+            ).format(
+                typ=type(array), cls=self.__class__.__name__, n=self._element_len,
+            )
+            raise ValueError(err_msg)
+
+        if isinstance(dtype, GeometryDtype):
+            dtype = dtype.subtype
+
+        numpy_dtype = None
+        pa_type = None
+        if isinstance(array, pa.Array):
+            if dtype is None:
+                invalid_array()
+            numpy_dtype = np.dtype(dtype)
+        elif isinstance(array, tuple):
+            if len(array) == self._element_len:
+                array = [np.asarray(array[i]) for i in range(len(array))]
+                if dtype:
+                    array = [array[i].astype(dtype) for i in range(len(array))]
+
+                # Capture numpy dtype
+                numpy_dtype = array[0].dtype
+
+                # Create buffer and FixedSizeBinaryArray
+                pa_type = pa.binary(
+                    self._element_len * pa.from_numpy_dtype(numpy_dtype).bit_width // 8
+                )
+                buffers = [None, pa.py_buffer(np.stack(array, axis=1).tobytes())]
+                array = pa.Array.from_buffers(
+                    pa_type, len(array[0]), buffers=buffers
+                )
+            else:
+                invalid_array()
+        else:
+            array = np.asarray(array)
+            if array.dtype.kind == 'O':
+                if array.ndim != 1:
+                    invalid_array()
+
+                # Try to infer dtype
+                if dtype is None:
+                    for i in range(len(array)):
+                        el = array[i]
+                        if el is None:
+                            continue
+                        if isinstance(el, GeometryFixed):
+                            numpy_dtype = el.numpy_dtype
+                        else:
+                            el_array = np.asarray(el)
+                            numpy_dtype = el_array.dtype
+                        break
+                    if numpy_dtype is None:
+                        invalid_array()
+                else:
+                    numpy_dtype = dtype
+
+                # Explicitly set the pyarrow binary type
+                pa_type = pa.binary(
+                    self._element_len * pa.from_numpy_dtype(numpy_dtype).bit_width // 8
+                )
+
+                # Convert individual rows to bytes
+                array = array.copy()
+                for i in range(len(array)):
+                    el = array[i]
+                    if el is None:
+                        continue
+                    if isinstance(el, bytes):
+                        # Nothing to do
+                        pass
+                    elif isinstance(el, GeometryFixed):
+                        array[i] = el.flat_values.tobytes()
+                    else:
+                        array[i] = np.asarray(el, dtype=numpy_dtype).tobytes()
+            else:
+                if dtype:
+                    array = array.astype(dtype)
+
+                # Capture numpy dtype
+                numpy_dtype = array.dtype
+                pa_type = pa.binary(
+                    self._element_len * pa.from_numpy_dtype(numpy_dtype).bit_width // 8
+                )
+
+                if array.ndim == 2:
+                    # Handle 2d array case
+                    if array.shape[1] != self._element_len:
+                        invalid_array()
+                    # Create buffer and FixedSizeBinaryArray
+                    buffers = [None, pa.py_buffer(array.tobytes())]
+                    array = pa.Array.from_buffers(
+                        pa_type, array.shape[0], buffers=buffers
+                    )
+                elif array.ndim == 1 and len(array) % self._element_len == 0:
+                    buffers = [None, pa.py_buffer(array.tobytes())]
+                    array = pa.Array.from_buffers(
+                        pa_type, len(array) // self._element_len, buffers=buffers
+                    )
+                else:
+                    invalid_array()
+
+        self._numpy_dtype = numpy_dtype
+        super(GeometryFixedArray, self).__init__(array, pa_type)
+
+    # Base geometry methods
+    @property
+    def flat_values(self):
+        if len(self.data) == 0:
+            return np.array([], dtype=self.numpy_dtype)
+        else:
+            start = self.data.offset
+            stop = start + len(self.data) * self._element_len
+            return np.asarray(self.data.buffers()[1]).view(self.numpy_dtype)[start:stop]
+
+    @property
+    def total_bounds(self):
+        return total_bounds_interleaved(self.flat_values)
+
+    @property
+    def total_bounds_x(self):
+        return total_bounds_interleaved_1d(self.flat_values, 0)
+
+    @property
+    def total_bounds_y(self):
+        return total_bounds_interleaved_1d(self.flat_values, 1)
+
+    @property
+    def bounds(self):
+        flat_values = self.flat_values
+        if len(flat_values) == 0:
+            return np.zeros((0, 4), dtype=self.numpy_dtype)
+        else:
+            bounds = np.full((len(self), 4), np.nan, dtype=np.float64)
+            bounds[~self.isna(), :] = bounds_interleaved(
+                flat_values, np.arange(0, len(flat_values) + 1, self._element_len)
+            )
+            return bounds

--- a/spatialpandas/geometry/baselist.py
+++ b/spatialpandas/geometry/baselist.py
@@ -126,7 +126,7 @@ class GeometryList(Geometry, _ListArrayBufferMixin):
     """
     _nesting_levels = 0
 
-    def __init__(self, data):
+    def __init__(self, data, dtype=None):
         super(GeometryList, self).__init__(data)
         if len(self.data) > 0:
             _validate_nested_arrow_type(self._nesting_levels, self.data.value_type)
@@ -175,13 +175,12 @@ class GeometryListArray(GeometryArray, _ListArrayBufferMixin):
 
         return arrow_dtype
 
-    @classmethod
-    def _numpy_element_dtype_from_arrow_type(cls, pyarrow_type):
+    def _numpy_element_dtype_from_arrow_type(self, pyarrow_type):
         if pyarrow_type == pa.null():
             return pa.null()
 
         pyarrow_element_type = pyarrow_type
-        for i in range(cls._nesting_levels):
+        for i in range(self._nesting_levels):
             pyarrow_element_type = pyarrow_element_type.value_type
 
         return pyarrow_element_type.to_pandas_dtype()

--- a/spatialpandas/geometry/basestruct.py
+++ b/spatialpandas/geometry/basestruct.py
@@ -1,0 +1,124 @@
+from functools import total_ordering
+
+import pyarrow as pa
+import numpy as np
+from spatialpandas.geometry import Geometry, GeometryArray, GeometryDtype
+
+
+@total_ordering
+class GeometryStruct(Geometry):
+    def __repr__(self):
+        flat_data = self._flat_data()
+        return "{}({})".format(self.__class__.__name__, flat_data)
+
+    def _flat_data(self):
+        pydata = self.data.as_py()
+        n = len(pydata) // 2
+        view_data = [pydata[f + str(i)] for i in range(n) for f in ['x', 'y']]
+        return view_data
+
+    def __hash__(self):
+        return hash((self.__class__, tuple(self._flat_data())))
+
+    def __lt__(self, other):
+        if type(other) is not type(self):
+            return NotImplemented
+        return tuple(self._flat_data()) < tuple(other._flat_data())
+
+
+class GeometryStructArray(GeometryArray):
+    _num_coords = 1
+    _element_type = GeometryStruct
+
+    @classmethod
+    def _arrow_type_from_numpy_element_dtype(cls, dtype):
+        # Scalar element dtype
+        arrow_dtype = pa.from_numpy_dtype(dtype)
+        return pa.struct([(field, arrow_dtype) for field in cls.fields()])
+
+    @classmethod
+    def _numpy_element_dtype_from_arrow_type(cls, pyarrow_type):
+        return pyarrow_type[0].type.to_pandas_dtype()
+
+    @classmethod
+    def fields(cls):
+        return [
+            d + str(i) for i in range(cls._num_coords) for d in ['x', 'y']
+        ]
+
+    def __init__(self, array, dtype=None):
+        def invalid_array():
+            err_msg = (
+                "Invalid array with type {typ}\n"
+                "A {cls} may constructed from:\n"
+                "    - A 1-d array with length divisible by {n} of interleaved\n"
+                "      x y coordinates\n"
+                "    - A tuple of {n} 1-d arrays\n"
+                "    - A list of dictionaries where each has the keys: {fields}.\n"
+                "      In this case the dtype argument must also be provided.\n"
+            ).format(
+                typ=type(array), cls=self.__class__.__name__,
+                n=2 * self._num_coords, fields=self.fields()
+            )
+            raise ValueError(err_msg)
+
+        if isinstance(dtype, GeometryDtype):
+            dtype = dtype.subtype
+
+        if isinstance(array, pa.Array):
+            if not isinstance(array, pa.StructArray):
+                invalid_array()
+        elif isinstance(array, tuple):
+            if len(array) == 2 * self._num_coords:
+                if dtype:
+                    [array[i].astype(dtype) for i in range(len(array))]
+                array = pa.StructArray.from_arrays(array, names=self.fields())
+            else:
+                invalid_array()
+        else:
+            array = np.asarray(array).ravel()
+            if array.dtype.kind == 'O':
+                fields = self.fields()
+                for i in range(len(array)):
+                    el = array[i]
+                    if isinstance(el, (list, np.ndarray)) and len(el) == len(fields):
+                        array[i] = {f: el[i] for i, f in enumerate(fields)}
+                if dtype is not None:
+                    patype = pa.from_numpy_dtype(dtype)
+                    dtype = pa.struct([(f, patype) for f in self.fields()])
+            else:
+                if dtype:
+                    array = array.astype(dtype)
+                if len(array) % (2 * self._num_coords) == 0:
+                    # interleaved
+                    array = array.reshape(
+                        (len(array) // (2 * self._num_coords),
+                         (2 * self._num_coords))
+                    )
+                    arrays = [array[:, i] for i in range(2 * self._num_coords)]
+                    array = pa.StructArray.from_arrays(arrays, names=self.fields())
+                else:
+                    invalid_array()
+
+        super(GeometryStructArray, self).__init__(array, dtype)
+
+        # Validate arrow type
+        arrow_type = self.data.type
+
+        def invalid_type():
+            err_msg = (
+                "Invalid element type {}\n"
+                "Expected StructType with fields: {}"
+            ).format(arrow_type, self.fields())
+
+            raise ValueError(err_msg)
+
+        if not isinstance(arrow_type, pa.StructType):
+            invalid_type()
+        elif arrow_type.num_children != self._num_coords * 2:
+            invalid_type()
+        for i in range(self._num_coords):
+            if arrow_type[2 * i].name != 'x' + str(i):
+                invalid_type()
+            if arrow_type[2 * i + 1].name != 'y' + str(i):
+                invalid_type()

--- a/spatialpandas/geometry/point.py
+++ b/spatialpandas/geometry/point.py
@@ -1,0 +1,160 @@
+from __future__ import absolute_import
+import numpy as np
+from pandas.core.dtypes.dtypes import register_extension_dtype
+
+from spatialpandas.geometry.base import GeometryDtype
+from spatialpandas.geometry.basefixed import GeometryFixed, GeometryFixedArray
+from dask.dataframe.extensions import make_array_nonempty
+
+
+@register_extension_dtype
+class PointDtype(GeometryDtype):
+    _geometry_name = 'point'
+    @classmethod
+    def construct_array_type(cls, *args):
+        return PointArray
+
+
+class Point(GeometryFixed):
+
+    @classmethod
+    def construct_array_type(cls):
+        return PointArray
+
+    @classmethod
+    def _shapely_to_coordinates(cls, shape):
+        import shapely.geometry as sg
+        if isinstance(shape, sg.Point):
+            # Single point
+            return np.asarray(shape.ctypes)
+        else:
+            raise ValueError("""
+Received invalid value of type {typ}. Must be an instance of Point,
+or MultiPoint""".format(typ=type(shape).__name__))
+
+    def to_shapely(self):
+        """
+        Convert to shapely shape
+
+        Returns:
+            shapely MultiPoint shape
+        """
+        import shapely.geometry as sg
+        return sg.Point(self.flat_values)
+
+    @classmethod
+    def from_shapely(cls, shape):
+        """
+        Build a spatialpandas Point object from a shapely shape
+
+        Args:
+            shape: A shapely MultiPoint or Point shape
+
+        Returns:
+            spatialpandas MultiPoint
+        """
+        return super(Point, cls).from_shapely(shape)
+
+    @property
+    def x(self):
+        return self.flat_values[0]
+
+    @property
+    def y(self):
+        return self.flat_values[1]
+
+    @property
+    def length(self):
+        return 0.0
+
+    @property
+    def area(self):
+        return 0.0
+
+    def intersects_bounds(self, bounds):
+        x0, y0, x1, y1 = bounds
+        if x1 < x0:
+            x0, x1 = x1, x0
+        if y1 < y0:
+            y0, y1 = y1, y0
+        outside = (np.isnan(self.x) or
+                   self.x < x0 or self.x > x1 or
+                   self.y < y0 or self.y > y1)
+
+        return not outside
+
+
+class PointArray(GeometryFixedArray):
+    _element_type = Point
+
+    @property
+    def _dtype_class(self):
+        return PointDtype
+
+    @classmethod
+    def from_geopandas(cls, ga):
+        """
+        Build a spatialpandas MultiPointArray from a geopandas GeometryArray or
+        GeoSeries.
+
+        Args:
+            ga: A geopandas GeometryArray or GeoSeries of MultiPoint or
+            Point shapes.
+
+        Returns:
+            MultiPointArray
+        """
+        return super(PointArray, cls).from_geopandas(ga)
+
+    @property
+    def length(self):
+        return np.zeros(len(self), dtype=np.float64)
+
+    @property
+    def area(self):
+        return np.zeros(len(self), dtype=np.float64)
+
+    @property
+    def x(self):
+        res = np.full(len(self), np.nan)
+        mask = ~self.isna()
+        res[mask] = self.flat_values[0::2][mask]
+        return res
+
+    @property
+    def y(self):
+        res = np.full(len(self), np.nan)
+        mask = ~self.isna()
+        res[mask] = self.flat_values[1::2][mask]
+        return res
+
+    def intersects_bounds(self, bounds, inds=None):
+        x0, y0, x1, y1 = bounds
+        if x1 < x0:
+            x0, x1 = x1, x0
+        if y1 < y0:
+            y0, y1 = y1, y0
+
+        xs = self.x
+        ys = self.y
+        if inds is not None:
+            xs = xs[inds]
+            ys = ys[inds]
+
+        outside = np.isnan(xs) | (xs < x0) | (xs > x1) | (ys < y0) | (ys > y1)
+        return ~outside
+
+
+def _points_array_non_empty(dtype):
+    """
+    Create an example length 2 array to register with Dask.
+    See https://docs.dask.org/en/latest/dataframe-extend.html#extension-arrays
+    """
+    return PointArray([
+        [1, 0],
+        [1, 2]
+    ], dtype=dtype)
+
+
+if make_array_nonempty:
+    make_array_nonempty.register(PointDtype)(_points_array_non_empty)

--- a/spatialpandas/io/parquet.py
+++ b/spatialpandas/io/parquet.py
@@ -16,12 +16,12 @@ from spatialpandas import GeoDataFrame
 from spatialpandas.dask import DaskGeoDataFrame
 from spatialpandas.geometry.base import to_geometry_array
 from spatialpandas.geometry import (
-    MultiPointDtype, RingDtype, LineDtype,
+    PointDtype, MultiPointDtype, RingDtype, LineDtype,
     MultiLineDtype, PolygonDtype, MultiPolygonDtype, GeometryDtype
 )
 
 _geometry_dtypes = [
-    MultiPointDtype, RingDtype, LineDtype,
+    PointDtype, MultiPointDtype, RingDtype, LineDtype,
     MultiLineDtype, PolygonDtype, MultiPolygonDtype
 ]
 

--- a/tests/geometry/strategies.py
+++ b/tests/geometry/strategies.py
@@ -25,6 +25,24 @@ st_points = arrays(
 
 
 @st.composite
+def st_point_array(draw, min_size=0, max_size=30, geoseries=False):
+    n = draw(st.integers(min_size, max_size))
+    points = []
+    for i in range(n):
+        x_mid = draw(st.floats(-50, 50))
+        y_mid = draw(st.floats(-50, 50))
+        point = (np.random.rand(2) - 0.5) * 5
+        point[0] = point[0] + x_mid
+        point[1] = point[1] + y_mid
+        points.append(sg.Point(point))
+
+    result = from_shapely(points)
+    if geoseries:
+        result = GeoSeries(result)
+    return result
+
+
+@st.composite
 def st_multipoint_array(draw, min_size=0, max_size=30, geoseries=False):
     n = draw(st.integers(min_size, max_size))
     lines = []

--- a/tests/geometry/test_construction.py
+++ b/tests/geometry/test_construction.py
@@ -1,0 +1,47 @@
+from spatialpandas.geometry import PointArray
+import numpy as np
+
+
+def test_construct_pointarray_interleaved():
+    src_array = np.array([0, 1, 2, 3, 4, 5, 6, 7], dtype=np.float32)
+    points = PointArray(src_array)
+
+    np.testing.assert_array_equal(points.x, src_array[0::2])
+    np.testing.assert_array_equal(points.y, src_array[1::2])
+    np.testing.assert_array_equal(points.isna(), np.isnan(src_array[0::2]))
+    np.testing.assert_array_equal(points.flat_values, src_array)
+
+
+def test_construct_pointarray_2d():
+    src_array = np.array([[0, 1], [2, 3], [4, 5], [6, 7]], dtype=np.float32)
+    points = PointArray(src_array)
+
+    np.testing.assert_array_equal(points.x, src_array[:, 0])
+    np.testing.assert_array_equal(points.y, src_array[:, 1])
+    np.testing.assert_array_equal(points.isna(), np.isnan(src_array[:, 0]))
+    np.testing.assert_array_equal(points.flat_values, src_array.flatten())
+
+
+def test_construct_pointarray_tuple():
+    src_array = np.array([[0, 1], [2, 3], [4, 5], [6, 7]], dtype=np.float32)
+    points = PointArray((src_array[:, 0], src_array[:, 1]))
+
+    np.testing.assert_array_equal(points.x, src_array[:, 0])
+    np.testing.assert_array_equal(points.y, src_array[:, 1])
+    np.testing.assert_array_equal(points.isna(), np.isnan(src_array[:, 0]))
+    np.testing.assert_array_equal(points.flat_values, src_array.flatten())
+
+
+def test_construct_pointarray_2d_with_None():
+    src_array = np.array([None, [2, 3], [4, 5], None])
+    expected_xs = np.array([np.nan, 2, 4, np.nan], dtype=np.float64)
+    expected_ys = np.array([np.nan, 3, 5, np.nan], dtype=np.float64)
+
+    points = PointArray(src_array)
+
+    np.testing.assert_array_equal(points.x, expected_xs)
+    np.testing.assert_array_equal(points.y, expected_ys)
+    np.testing.assert_array_equal(points.isna(), np.isnan(expected_xs))
+    np.testing.assert_array_equal(
+        points.flat_values[2:6], np.array([2, 3, 4, 5], dtype=np.int64)
+    )

--- a/tests/geometry/test_cx.py
+++ b/tests/geometry/test_cx.py
@@ -3,16 +3,27 @@ from pandas.testing import assert_series_equal, assert_frame_equal
 import dask.dataframe as dd
 from spatialpandas import GeoSeries, GeoDataFrame
 from spatialpandas.geometry import (
-    MultiPointArray, LineArray, MultiLineArray, PolygonArray, MultiPolygonArray
-)
+    MultiPointArray, LineArray, MultiLineArray, PolygonArray, MultiPolygonArray,
+    PointArray)
 from tests.geometry.strategies import (
     st_multipoint_array, st_bounds, st_line_array, st_multiline_array,
-    st_polygon_array, st_multipolygon_array, hyp_settings
-)
+    st_polygon_array, st_multipolygon_array, hyp_settings,
+    st_point_array)
 
 
 def get_slices(v0, v1):
     return [slice(v0, v1), slice(None, v1), slice(v0, None), slice(None, None)]
+
+
+@given(st_point_array(min_size=1, geoseries=True), st_bounds(orient=True))
+@hyp_settings
+def test_multipoint_cx_selection(gp_point, rect):
+    x0, y0, x1, y1 = rect
+    for xslice in get_slices(x0, x1):
+        for yslice in get_slices(y0, y1):
+            expected = PointArray.from_geopandas(gp_point.cx[xslice, yslice])
+            result = PointArray.from_geopandas(gp_point).cx[xslice, yslice]
+            assert all(expected == result)
 
 
 @given(st_multipoint_array(min_size=1, geoseries=True), st_bounds(orient=True))

--- a/tests/geometry/test_geometry.py
+++ b/tests/geometry/test_geometry.py
@@ -1,6 +1,6 @@
 import numpy as np
 from spatialpandas.geometry import (
-    MultiPoint, MultiPointArray, Line, LineArray,
+    Point, PointArray, MultiPoint, MultiPointArray, Line, LineArray,
     MultiLine, MultiLineArray, Polygon, PolygonArray,
     MultiPolygon, MultiPolygonArray
 )
@@ -9,13 +9,26 @@ unit_square_cw = np.array([1, 1,  1, 2,  2, 2,  2, 1,  1, 1], dtype='float64')
 large_square_ccw = np.array([0, 0, 3, 0, 3, 3, 0, 3, 0, 0], dtype='float64')
 
 
-def test_points():
+def test_point():
+    point = Point([1, 2])
+    assert point.length == 0.0
+    assert point.area == 0.0
+
+
+def test_point_array():
+    points = PointArray(unit_square_cw)
+    np.testing.assert_equal(points.length, [0.0, 0.0, 0.0, 0.0, 0.0])
+    np.testing.assert_equal(points.area, [0.0, 0.0, 0.0, 0.0, 0.0])
+    assert points.total_bounds == (1, 1, 2, 2)
+
+
+def test_multipoint():
     points = MultiPoint(unit_square_cw)
     assert points.length == 0.0
     assert points.area == 0.0
 
 
-def test_points_array():
+def test_multipoint_array():
     points = MultiPointArray([
         unit_square_cw,
         large_square_ccw,

--- a/tests/geometry/test_to_geopandas.py
+++ b/tests/geometry/test_to_geopandas.py
@@ -3,8 +3,15 @@ from pandas.testing import assert_series_equal
 from spatialpandas import GeoSeries
 from tests.geometry.strategies import (
     st_multipoint_array, st_bounds, st_line_array, st_multiline_array,
-    st_polygon_array, st_multipolygon_array, hyp_settings
-)
+    st_polygon_array, st_multipolygon_array, hyp_settings,
+    st_point_array)
+
+
+@given(st_point_array(geoseries=True))
+@hyp_settings
+def test_point_array_to_geopandas(gp_point):
+    result = GeoSeries(gp_point, dtype='point').to_geopandas()
+    assert_series_equal(result, gp_point)
 
 
 @given(st_multipoint_array(geoseries=True))

--- a/tests/test_fixedextensionarray.py
+++ b/tests/test_fixedextensionarray.py
@@ -1,0 +1,193 @@
+import pandas.tests.extension.base as eb
+import pytest
+from spatialpandas.geometry import PointArray, PointDtype
+
+
+def test_equality():
+    a = PointArray([[0, 1], [1, 2], None, [-1, -2], [7, 3]], dtype='float64')
+    assert all(a == a)
+    assert all(a[1:-1] == a[[1, 2, 3]])
+    assert not any(a[1:-1] == a[[2, 3, 1]])
+
+
+# Pandas-provided extension array tests
+# -------------------------------------
+# See http://pandas-docs.github.io/pandas-docs-travis/extending.html
+#
+# Fixtures
+@pytest.fixture
+def dtype():
+    """A fixture providing the ExtensionDtype to validate."""
+    return PointDtype(subtype='float64')
+
+
+@pytest.fixture
+def data():
+    """Length-100 array for this type.
+        * data[0] and data[1] should both be non missing
+        * data[0] and data[1] should not gbe equal
+        """
+    return PointArray(
+        [[0, 1], [1, 2], [3, 4], None, [-1, -2]]*20, dtype='float64')
+
+
+@pytest.fixture
+def data_repeated(data):
+    """
+    Generate many datasets.
+    Parameters
+    ----------
+    data : fixture implementing `data`
+    Returns
+    -------
+    Callable[[int], Generator]:
+        A callable that takes a `count` argument and
+        returns a generator yielding `count` datasets.
+    """
+    def gen(count):
+        for _ in range(count):
+            yield data
+    return gen
+
+
+@pytest.fixture
+def data_missing():
+    """Length-2 array with [NA, Valid]"""
+    return PointArray([None, [-1, 0]], dtype='int64')
+
+
+@pytest.fixture(params=['data', 'data_missing'])
+def all_data(request, data, data_missing):
+    """Parametrized fixture giving 'data' and 'data_missing'"""
+    if request.param == 'data':
+        return data
+    elif request.param == 'data_missing':
+        return data_missing
+
+
+@pytest.fixture
+def data_for_sorting():
+    """Length-3 array with a known sort order.
+    This should be three items [B, C, A] with
+    A < B < C
+    """
+    return PointArray([[1, 0], [2, 0], [0, 0]])
+
+
+@pytest.fixture
+def data_missing_for_sorting():
+    """Length-3 array with a known sort order.
+    This should be three items [B, NA, A] with
+    A < B and NA missing.
+    """
+    return PointArray([[1, 0], None, [0, 0]])
+
+
+@pytest.fixture
+def data_for_grouping():
+    """Data for factorization, grouping, and unique tests.
+    Expected to be like [B, B, NA, NA, A, A, B, C]
+    Where A < B < C and NA is missing
+    """
+    return PointArray(
+        [[1, 0], [1, 0], None, None, [0, 0], [0, 0], [1, 0], [2, 0]])
+
+
+@pytest.fixture
+def na_cmp():
+    return lambda x, y: x is None and y is None
+
+
+@pytest.fixture
+def na_value():
+    return None
+
+
+@pytest.fixture
+def groupby_apply_op():
+    return lambda x: [1] * len(x)
+
+
+@pytest.fixture
+def fillna_method():
+    return 'ffill'
+
+
+@pytest.fixture(params=[True, False])
+def as_frame(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def as_series(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def use_numpy(request):
+    return request.param
+
+
+# Subclass BaseDtypeTests to run pandas-provided extension array test suite
+class TestGeometryConstructors(eb.BaseConstructorsTests):
+    pass
+
+
+class TestGeometryDtype(eb.BaseDtypeTests):
+    pass
+
+
+class TestGeometryGetitem(eb.BaseGetitemTests):
+    @pytest.mark.skip(reason="non-None fill value not supported")
+    def test_take_non_na_fill_value(self):
+        pass
+
+    @pytest.mark.skip(reason="non-None fill value not supported")
+    def test_reindex_non_na_fill_value(self, data_missing):
+        pass
+
+
+class TestGeometryGroupby(eb.BaseGroupbyTests):
+    pass
+
+
+class TestGeometryInterface(eb.BaseInterfaceTests):
+    # # NotImplementedError: 'GeometryList' does not support __setitem__
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_copy(self):
+        pass
+
+
+class TestGeometryMethods(eb.BaseMethodsTests):
+    # # AttributeError: 'RaggedArray' object has no attribute 'value_counts'
+    @pytest.mark.skip(reason="value_counts not supported")
+    def test_value_counts(self):
+        pass
+
+    # Ragged array elements don't support binary operators
+    @pytest.mark.skip(reason="ragged does not support <= on elements")
+    def test_combine_le(self):
+        pass
+
+    @pytest.mark.skip(reason="ragged does not support + on elements")
+    def test_combine_add(self):
+        pass
+
+    @pytest.mark.skip(reason="combine_first not supported")
+    def test_combine_first(self):
+        pass
+
+
+class TestGeometryPrinting(eb.BasePrintingTests):
+    pass
+
+
+class TestGeometryMissing(eb.BaseMissingTests):
+    pass
+
+
+class TestGeometryReshaping(eb.BaseReshapingTests):
+    @pytest.mark.skip(reason="__setitem__ not supported")
+    def test_ravel(self):
+        pass
+

--- a/tests/test_parquet.py
+++ b/tests/test_parquet.py
@@ -5,7 +5,7 @@ from spatialpandas import GeoSeries, GeoDataFrame
 from spatialpandas.dask import DaskGeoDataFrame
 from tests.geometry.strategies import (
     st_multipoint_array, st_multiline_array,
-)
+    st_point_array)
 import numpy as np
 from spatialpandas.io import (
     to_parquet, read_parquet, read_parquet_dask, to_parquet_dask
@@ -15,16 +15,18 @@ hyp_settings = settings(deadline=None, max_examples=100)
 
 
 @given(
+    gp_point=st_point_array(min_size=1, geoseries=True),
     gp_multipoint=st_multipoint_array(min_size=1, geoseries=True),
     gp_multiline=st_multiline_array(min_size=1, geoseries=True),
 )
 @hyp_settings
-def test_parquet(gp_multipoint, gp_multiline, tmp_path):
+def test_parquet(gp_point, gp_multipoint, gp_multiline, tmp_path):
     # Build dataframe
     n = min(len(gp_multipoint), len(gp_multiline))
     df = GeoDataFrame({
-        'points': GeoSeries(gp_multipoint[:n]),
-        'lines': GeoSeries(gp_multiline[:n]),
+        'point': GeoSeries(gp_point[:n]),
+        'multipoint': GeoSeries(gp_multipoint[:n]),
+        'multiline': GeoSeries(gp_multiline[:n]),
         'a': list(range(n))
     })
 


### PR DESCRIPTION
This PR adds a `PointArray` geometry type for the storage of individual points. These are backed by pyarrow fixed width binary arrays.  Like the rest of the geometry types, these support serialization to and from parquet.

